### PR TITLE
feat(ir): Rewrite IR generation to deal with dependencies in instruction generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/third_party

--- a/src/sema.rs
+++ b/src/sema.rs
@@ -105,7 +105,11 @@ impl SymbolTable {
     // the range of symbol tables stack.
     pub fn find(&self, name: &str, start: usize) -> Option<&Symbol> {
         // Get a reference to the current scope we're processing
-        let mut idx = start;
+        let mut idx = if start >= self.tables.len() {
+            self.tables.len() - 1
+        } else {
+            start
+        };
         let mut current_scope_table = &self.tables[idx];
         while idx >= self.root {
             // Try and find the declaration in the current scope.
@@ -718,7 +722,7 @@ impl<'a> ast::Visitor<()> for SemanticAnalyzer<'a> {
                         t,
                         DeclType::Bool,
                         "invalid expression type in `if` statement, must be of type bool found {t}"
-                    )
+                    );
                 } else {
                     unreachable!("Expression at ref {} was not found.", condition.get())
                 }


### PR DESCRIPTION
When generating instructions there's often a dependency on the previously generated instruction. This comes up when generating function body that references arguments and assignment expressions. This PR tracks rewriting the IR generation pass to return a tuple of `(Option<String>, Vec<Instruction>)` which represents the last variable name (either a temporary from the temporary variable stack or a named identifier from source) and the instruction bundle of the previously visited expression or statement.